### PR TITLE
reset the extension data while building ABORT flyweight

### DIFF
--- a/src/main/java/org/reaktivity/reaktor/internal/acceptable/Acceptable.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/acceptable/Acceptable.java
@@ -211,6 +211,7 @@ public final class Acceptable extends Nukleus.Composite implements RouteManager
     {
         final AbortFW abort = abortRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                                      .streamId(streamId)
+                                     .extension(e -> e.reset())
                                      .build();
 
         stream.accept(abortTypeId, abort.buffer(), abort.offset(), abort.sizeof());


### PR DESCRIPTION
reset the extension data while building ABORT flyweight (otherwise, much bigger
frame is built)