### PR TITLE
Allow nuklei to control whether route ref 0 is valid or should cause a new route ref to be generated 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <nukleus.plugin.version>0.13</nukleus.plugin.version>
     <nukleus.spec.version>0.13</nukleus.spec.version>
-    <nukleus.version>0.13</nukleus.version>
+    <nukleus.version>develop-SNAPSHOT</nukleus.version>
     <jmock.version>2.6.0</jmock.version>
     <mockito.version>2.7.13</mockito.version>
     <k3po.version>3.0.0-alpha-84</k3po.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <nukleus.plugin.version>0.13</nukleus.plugin.version>
     <nukleus.spec.version>0.13</nukleus.spec.version>
-    <nukleus.version>develop-SNAPSHOT</nukleus.version>
+    <nukleus.version>0.14</nukleus.version>
     <jmock.version>2.6.0</jmock.version>
     <mockito.version>2.7.13</mockito.version>
     <k3po.version>3.0.0-alpha-84</k3po.version>

--- a/src/main/java/org/reaktivity/reaktor/internal/NukleusBuilderImpl.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/NukleusBuilderImpl.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.agrona.collections.Int2ObjectHashMap;
@@ -50,6 +51,7 @@ public class NukleusBuilderImpl implements NukleusBuilder
     private final Map<Role, MessagePredicate> routeHandlers;
     private final Map<RouteKind, StreamFactoryBuilder> streamFactoryBuilders;
     private final List<Nukleus> components;
+    private Predicate<RouteKind> allowZeroRouteRef = r -> false;
 
     public NukleusBuilderImpl(
         ReaktorConfiguration config,
@@ -110,6 +112,14 @@ public class NukleusBuilderImpl implements NukleusBuilder
     }
 
     @Override
+    public NukleusBuilder allowZeroRouteRef(
+        Predicate<RouteKind> predicate)
+    {
+        this.allowZeroRouteRef = predicate;
+        return this;
+    }
+
+    @Override
     public NukleusBuilder streamFactory(
         RouteKind kind,
         StreamFactoryBuilder builder)
@@ -151,6 +161,7 @@ public class NukleusBuilderImpl implements NukleusBuilder
         acceptor.setStreamFactoryBuilderSupplier(streamFactoryBuilders::get);
         acceptor.setAbortTypeId(abortTypeId);
         acceptor.setRouteHandlerSupplier(routeHandlers::get);
+        acceptor.setAllowZeroRouteRef(allowZeroRouteRef);
 
         return new NukleusImpl(name, conductor, watcher, router, acceptor, context, components);
     }

--- a/src/main/java/org/reaktivity/reaktor/internal/NukleusBuilderImpl.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/NukleusBuilderImpl.java
@@ -113,9 +113,9 @@ public class NukleusBuilderImpl implements NukleusBuilder
 
     @Override
     public NukleusBuilder allowZeroRouteRef(
-        Predicate<RouteKind> predicate)
+        Predicate<RouteKind> allowZeroRouteRef)
     {
-        this.allowZeroRouteRef = predicate;
+        this.allowZeroRouteRef = allowZeroRouteRef;
         return this;
     }
 

--- a/src/test/java/org/reaktivity/reaktor/internal/streams/MultipleStreamsIT.java
+++ b/src/test/java/org/reaktivity/reaktor/internal/streams/MultipleStreamsIT.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.reaktivity.nukleus.route.RouteKind.SERVER;
 
 import java.util.function.Function;
+import java.util.function.IntUnaryOperator;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -101,8 +102,10 @@ public class MultipleStreamsIT
         private ArgumentCaptor<RouteManager> router = forClass(RouteManager.class);
         private ArgumentCaptor<LongSupplier> supplyStreamId = forClass(LongSupplier.class);
         private ArgumentCaptor<LongSupplier> supplyGroupId = forClass(LongSupplier.class);
-        private ArgumentCaptor<LongFunction> groupBudgetClaimer = forClass(LongFunction.class);
-        private ArgumentCaptor<LongFunction> groupBudgetReleaser = forClass(LongFunction.class);
+        @SuppressWarnings("unchecked")
+        private ArgumentCaptor<LongFunction<IntUnaryOperator>> groupBudgetClaimer = forClass(LongFunction.class);
+        @SuppressWarnings("unchecked")
+        private ArgumentCaptor<LongFunction<IntUnaryOperator>> groupBudgetReleaser = forClass(LongFunction.class);
         private ArgumentCaptor<MutableDirectBuffer> writeBuffer = forClass(MutableDirectBuffer.class);
 
         private MessageConsumer newStream1 = mock(MessageConsumer.class);

--- a/src/test/java/org/reaktivity/reaktor/internal/streams/StreamsIT.java
+++ b/src/test/java/org/reaktivity/reaktor/internal/streams/StreamsIT.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.reaktivity.nukleus.route.RouteKind.SERVER;
 
 import java.util.function.Function;
+import java.util.function.IntUnaryOperator;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -143,8 +144,10 @@ public class StreamsIT
         private ArgumentCaptor<RouteManager> router = forClass(RouteManager.class);
         private ArgumentCaptor<LongSupplier> supplyStreamId = forClass(LongSupplier.class);
         private ArgumentCaptor<LongSupplier> supplyGroupId = forClass(LongSupplier.class);
-        private ArgumentCaptor<LongFunction> groupBudgetClaimer = forClass(LongFunction.class);
-        private ArgumentCaptor<LongFunction> groupBudgetReleaser = forClass(LongFunction.class);
+        @SuppressWarnings("unchecked")
+        private ArgumentCaptor<LongFunction<IntUnaryOperator>> groupBudgetClaimer = forClass(LongFunction.class);
+        @SuppressWarnings("unchecked")
+        private ArgumentCaptor<LongFunction<IntUnaryOperator>> groupBudgetReleaser = forClass(LongFunction.class);
         private ArgumentCaptor<MutableDirectBuffer> writeBuffer = forClass(MutableDirectBuffer.class);
 
         private MessageConsumer newStream = mock(MessageConsumer.class);


### PR DESCRIPTION
Implements the interface change in https://github.com/reaktivity/nukleus.java/pull/7

These changes should be backward compatible. I have verified this with the http and http2 nuklei.
  