### PR TITLE
Changed Router.routeMatchesUnroute to match extensions as well as the…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     <jacoco.coverage.ratio>0.41</jacoco.coverage.ratio>
     <jacoco.missed.count>65</jacoco.missed.count>
 
-    <nukleus.plugin.version>0.28</nukleus.plugin.version>
-    <nukleus.spec.version>0.21</nukleus.spec.version>
+    <nukleus.plugin.version>0.29</nukleus.plugin.version>
+    <nukleus.spec.version>develop-SNAPSHOT</nukleus.spec.version>
     <nukleus.version>0.21</nukleus.version>
     <jmock.version>2.6.0</jmock.version>
     <mockito.version>2.7.13</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <jacoco.missed.count>65</jacoco.missed.count>
 
     <nukleus.plugin.version>0.29</nukleus.plugin.version>
-    <nukleus.spec.version>develop-SNAPSHOT</nukleus.spec.version>
+    <nukleus.spec.version>0.22</nukleus.spec.version>
     <nukleus.version>0.21</nukleus.version>
     <jmock.version>2.6.0</jmock.version>
     <mockito.version>2.7.13</mockito.version>

--- a/src/main/java/org/reaktivity/reaktor/internal/router/Router.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/router/Router.java
@@ -452,6 +452,7 @@ public final class Router extends Nukleus.Composite implements RouteManager
         unroute.target().asString().equals(route.target().asString()) &&
         unroute.targetRef() == route.targetRef() &&
         unroute.authorization() == route.authorization() &&
+        unroute.extension().equals(route. extension()) &&
         routeHandler.test(UnrouteFW.TYPE_ID, route.buffer(), route.offset(), route.limit());
     }
 

--- a/src/test/java/org/reaktivity/reaktor/internal/control/ControlIT.java
+++ b/src/test/java/org/reaktivity/reaktor/internal/control/ControlIT.java
@@ -101,6 +101,15 @@ public class ControlIT
 
     @Test
     @Specification({
+        "${control}/route/server/multiple.extensions/controller"
+    })
+    public void shouldRouteByExtensionAsServer() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${control}/route/server/controller"
     })
     @ScriptProperty("routeAuthorization 0x0001_000000000000L")
@@ -157,6 +166,28 @@ public class ControlIT
     @ScriptProperty({"route1Authorization 0x0001_000000000000L",
                      "route2Authorization 0x0001_000000000001L"})
     public void shouldUnrouteAsServerWithMultipleRoutes() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route/server/multiple.authorizations/controller",
+        "${control}/unroute/server/multiple.authorizations/controller"
+    })
+    @ScriptProperty({"route1Authorization 0x0001_000000000000L",
+                     "route2Authorization 0x0002_000000000000L"})
+    public void shouldUnrouteByAuthorizationAsServer() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${control}/route/server/multiple.extensions/controller",
+        "${control}/unroute/server/multiple.extensions/controller"
+    })
+    public void shouldUnrouteByExtensionAsServer() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
as well as the other fields to allow multiple routes distinguished only by extension data to be individually unrouted.

Requires: https://github.com/reaktivity/nukleus.spec/pull/24