### PR TITLE
Reaktor.maximum.messages.per.read

### DIFF
--- a/src/main/java/org/reaktivity/reaktor/internal/Context.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/Context.java
@@ -57,6 +57,7 @@ public final class Context implements Closeable
     private RingBuffer toConductorCommands;
     private AtomicBuffer fromConductorResponseBuffer;
     private BroadcastTransmitter fromConductorResponses;
+    private int maximumMessagesPerRead;
 
     private Path streamsPath;
 
@@ -80,6 +81,12 @@ public final class Context implements Closeable
     {
         return maximumStreamsCount;
     }
+
+    public int maximumMessagesPerRead()
+    {
+        return maximumMessagesPerRead;
+    }
+
 
     public int streamsBufferCapacity()
     {
@@ -262,6 +269,8 @@ public final class Context implements Closeable
             this.streamsBufferCapacity = config.streamsBufferCapacity();
 
             this.throttleBufferCapacity = config.throttleBufferCapacity();
+
+            this.maximumMessagesPerRead = config.maximumMessagesPerRead();
 
             this.maximumControlCommandLength = config.commandBufferCapacity() / 8;
 

--- a/src/main/java/org/reaktivity/reaktor/internal/ReaktorConfiguration.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/ReaktorConfiguration.java
@@ -46,6 +46,8 @@ public class ReaktorConfiguration extends Configuration
 
     public static final String TIMESTAMPS_PROPERTY_NAME = "reaktor.timestamps";
 
+    public static final String MAXIMUM_MESSAGES_PER_READ_PROPERTY_NAME = "reaktor.maximum.messages.per.read";
+
     public static final String BACKOFF_IDLE_STRATEGY_MAX_SPINS = "reaktor.backoff.idle.strategy.max.spins";
 
     public static final String BACKOFF_IDLE_STRATEGY_MAX_YIELDS = "reaktor.backoff.idle.strategy.max.yields";
@@ -77,6 +79,8 @@ public class ReaktorConfiguration extends Configuration
     private static final long BACKOFF_IDLE_STRATEGY_MAX_PARK_PERIOD_NANOS_DEFAULT = MILLISECONDS.toNanos(1L);
 
     private static final boolean TIMESTAMPS_DEFAULT = true;
+
+    private static final int MAXIMUM_MESSAGES_PER_READ_DEFAULT = Integer.MAX_VALUE;
 
     public ReaktorConfiguration(
         Configuration config)
@@ -117,6 +121,11 @@ public class ReaktorConfiguration extends Configuration
     public int maximumStreamsCount()
     {
         return bufferPoolCapacity() / bufferSlotCapacity();
+    }
+
+    public int maximumMessagesPerRead()
+    {
+        return getInteger(MAXIMUM_MESSAGES_PER_READ_PROPERTY_NAME, MAXIMUM_MESSAGES_PER_READ_DEFAULT);
     }
 
     @Override

--- a/src/main/java/org/reaktivity/reaktor/internal/router/Router.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/router/Router.java
@@ -399,7 +399,7 @@ public final class Router extends Nukleus.Composite implements RouteManager
                 .readonly(true)
                 .build();
 
-        return include(new Target(context.name(), targetName, layout, writeBuffer, timestamps));
+        return include(new Target(context.name(), targetName, layout, writeBuffer, timestamps, context.maximumMessagesPerRead()));
     }
 
     private Source supplySource(

--- a/src/main/java/org/reaktivity/reaktor/internal/router/Source.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/router/Source.java
@@ -107,7 +107,8 @@ final class Source implements Nukleus
 
         this.layout = layout;
         this.streamsDescriptor = layout::toString;
-        this.streamsBuffer = layout.streamsBuffer()::read;
+        final int messageCountLimit = context.maximumMessagesPerRead();
+        this.streamsBuffer = m -> layout.streamsBuffer().read(m, messageCountLimit);
         this.throttleBuffer = layout.throttleBuffer()::write;
 
         final Map<RouteKind, StreamFactory> streamFactories = new EnumMap<>(RouteKind.class);

--- a/src/main/java/org/reaktivity/reaktor/internal/router/Target.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/router/Target.java
@@ -59,7 +59,8 @@ final class Target implements Nukleus
         String targetName,
         StreamsLayout layout,
         MutableDirectBuffer writeBuffer,
-        boolean timestamps)
+        boolean timestamps,
+        int maximumMessagesPerRead)
     {
         this.nukleusName = nukleusName;
         this.targetName = targetName;
@@ -67,7 +68,7 @@ final class Target implements Nukleus
         this.writeBuffer = writeBuffer;
         this.timestamps = timestamps;
         this.streamsBuffer = layout.streamsBuffer()::write;
-        this.throttleBuffer = layout.throttleBuffer()::read;
+        this.throttleBuffer = m -> layout.throttleBuffer().read(m, maximumMessagesPerRead);
         this.throttles = new Long2ObjectHashMap<>();
         this.readHandler = this::handleRead;
         this.writeHandler = this::handleWrite;


### PR DESCRIPTION
Adds a new configuration parameter (system property) `reaktor.maximum.messages.per.read` to control how many messages are read each time a RingBuffer is read (for each source and throttle)