### PR TITLE
Making Resolver to be thread local object

### DIFF
--- a/src/main/java/org/reaktivity/reaktor/internal/agent/ElektronAgent.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/agent/ElektronAgent.java
@@ -228,39 +228,51 @@ public class ElektronAgent implements Agent
 
     private static class ResolverRef implements RouteManager
     {
-        final ThreadLocal<Resolver> resolver;
+        private final ThreadLocal<Resolver> resolver;
 
-        ResolverRef(Supplier<Resolver> resolverSupplier)
+        ResolverRef(
+            Supplier<Resolver> supplyResolver)
         {
-            resolver = ThreadLocal.withInitial(resolverSupplier);
+            resolver = ThreadLocal.withInitial(supplyResolver);
         }
 
         @Override
-        public <R> R resolveExternal(long authorization, MessagePredicate filter, MessageFunction<R> mapper)
+        public <R> R resolveExternal(
+            long authorization,
+            MessagePredicate filter,
+            MessageFunction<R> mapper)
         {
             return resolver.get().resolveExternal(authorization, filter, mapper);
         }
 
         @Override
-        public <R> R resolve(long routeId, long authorization, MessagePredicate filter, MessageFunction<R> mapper)
+        public <R> R resolve(
+            long routeId,
+            long authorization,
+            MessagePredicate filter,
+            MessageFunction<R> mapper)
         {
             return resolver.get().resolve(routeId, authorization, filter, mapper);
         }
 
         @Override
-        public void forEach(MessageConsumer consumer)
+        public void forEach(
+            MessageConsumer consumer)
         {
             resolver.get().forEach(consumer);
         }
 
         @Override
-        public MessageConsumer supplyReceiver(long streamId)
+        public MessageConsumer supplyReceiver(
+            long streamId)
         {
             return resolver.get().supplyReceiver(streamId);
         }
 
         @Override
-        public void setThrottle(long streamId, MessageConsumer throttle)
+        public void setThrottle(
+            long streamId,
+            MessageConsumer throttle)
         {
             resolver.get().setThrottle(streamId, throttle);
         }

--- a/src/main/java/org/reaktivity/reaktor/internal/router/Resolver.java
+++ b/src/main/java/org/reaktivity/reaktor/internal/router/Resolver.java
@@ -36,7 +36,7 @@ import org.reaktivity.reaktor.internal.types.state.RouteTableFW;
 
 public final class Resolver implements RouteManager
 {
-    private final ThreadLocal<RouteFW> routeRO = ThreadLocal.withInitial(RouteFW::new);
+    private final RouteFW routeRO = new RouteFW();
     private final RouteTableFW routeTableRO = new RouteTableFW();
 
     private final Int2ObjectHashMap<MessageConsumer>[] throttles;
@@ -80,7 +80,7 @@ public final class Resolver implements RouteManager
         final RouteEntryFW routeEntry = routeTable.entries().matchFirst(re ->
         {
             final OctetsFW entry = re.route();
-            final RouteFW candidate = routeRO.get().wrap(entry.buffer(), entry.offset(), entry.limit());
+            final RouteFW candidate = routeRO.wrap(entry.buffer(), entry.offset(), entry.limit());
             return (authorization & candidate.authorization()) == candidate.authorization() &&
                    filter.test(candidate.typeId(), candidate.buffer(), candidate.offset(), candidate.sizeof());
         });
@@ -89,7 +89,7 @@ public final class Resolver implements RouteManager
         if (routeEntry != null)
         {
             final OctetsFW entry = routeEntry.route();
-            final RouteFW route = routeRO.get().wrap(entry.buffer(), entry.offset(), entry.limit());
+            final RouteFW route = routeRO.wrap(entry.buffer(), entry.offset(), entry.limit());
             result = mapper.apply(route.typeId(), route.buffer(), route.offset(), route.sizeof());
         }
         return result;
@@ -108,7 +108,7 @@ public final class Resolver implements RouteManager
         RouteEntryFW routeEntry = routeTable.entries().matchFirst(re ->
         {
             final OctetsFW entry = re.route();
-            final RouteFW candidate = routeRO.get().wrap(entry.buffer(), entry.offset(), entry.limit());
+            final RouteFW candidate = routeRO.wrap(entry.buffer(), entry.offset(), entry.limit());
             return remoteId(routeId) == localId(candidate.correlationId()) &&
                    (authorization & candidate.authorization()) == candidate.authorization() &&
                    filter.test(candidate.typeId(), candidate.buffer(), candidate.offset(), candidate.sizeof());
@@ -118,7 +118,7 @@ public final class Resolver implements RouteManager
         if (routeEntry != null)
         {
             final OctetsFW entry = routeEntry.route();
-            final RouteFW route = routeRO.get().wrap(entry.buffer(), entry.offset(), entry.limit());
+            final RouteFW route = routeRO.wrap(entry.buffer(), entry.offset(), entry.limit());
             result = mapper.apply(route.typeId(), route.buffer(), route.offset(), route.sizeof());
         }
         return result;
@@ -134,7 +134,7 @@ public final class Resolver implements RouteManager
         routeTable.entries().forEach(re ->
         {
             final OctetsFW entry = re.route();
-            final RouteFW route = routeRO.get().wrap(entry.buffer(), entry.offset(), entry.limit());
+            final RouteFW route = routeRO.wrap(entry.buffer(), entry.offset(), entry.limit());
             consumer.accept(route.typeId(), route.buffer(), route.offset(), route.sizeof());
         });
     }


### PR DESCRIPTION
Making Resolver to be thread local object, so that the internal flyweights
of resolver are scoped to thread implicitly.